### PR TITLE
decide on sympy.sinc lambdification; issue #31

### DIFF
--- a/src/SymPy/gen_methods_sympy.jl
+++ b/src/SymPy/gen_methods_sympy.jl
@@ -55,6 +55,13 @@ end
 
 Base.sinpi(x::Sym) = sin(PI*x)
 Base.cospi(x::Sym) = cos(PI*x)
+"""
+    sinc(x::Sym)
+
+Returns `sin(PI*x)/(PI*x)`.
+
+In the sympy library, `sinc` refers to `sin(x)/x`, differing from `Julia`. When `sympy.sinc(x)` is "lambdified" the value of `sin(x)/x` is used.
+"""
 Base.sinc(x::Sym) = iszero(x) ? one(x) : sinpi(x)/(PI*x)
 Base.cosc(x::Sym) = cospi(x)/x - sinc(x)/x
 

--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -152,6 +152,7 @@ _ALL_(xs...) = all(xs) # all∘tuple
 _ZERO_(xs...) = 0      #
 # not quite a match; NaN not θ(0) when evaluated at 0 w/o second argument
 _HEAVISIDE_(a...)  = (a[1] < 0 ? 0 : (a[1] > 0 ? 1 : (length(a) > 1 ? a[2] : NaN)))
+_sinc_(x) = iszero(x) ? 1 : sin(x)/x # sympy.sinc ->
 
 ## Map to get function object from type information
 # we may want fn or expression, Symbol(+) yields :+ but allocates to make a string
@@ -180,6 +181,7 @@ sympy_fn_julia_fn = Dict(
     "GreaterThan" => (>=, :(>=)),
     "Greater" => (>, :(>)),
     #
+    "sinc" => (SymPyCore._sinc_, :(SymPyCore._sinc_)),
     "Piecewise" => (SymPyCore._piecewise,  :(SymPyCore._piecewise)),
     "Heaviside" => (SymPyCore._HEAVISIDE_, :(SymPyCore._HEAVISIDE_)),
     "Order" =>     (SymPyCore._ZERO_,      :(SymPyCore._ZERO_)),

--- a/test/test-math.jl
+++ b/test/test-math.jl
@@ -37,6 +37,15 @@ using SymPyCore
     @test sinc(Sym(1)) == 0
     @test N(sinc(Sym(0.2))) ≈ sinc(0.2)
 
+    # we have sinc(x) -> sin(PI*x)/(PI*x) *but*
+    # sympy.sinc(x) as sin(x)/x (their choice).
+    # What do do with lambdify(sympy.sinc(x))? we keep the SymPy
+    @syms x
+    @test lambdify(sinc(x))(1/2) ≈ sinc(1/2)
+    @test lambdify(sympy.sinc(x))(1/2) ≈ sinc(1/2/pi)
+
+
+
     @test flipsign(Sym(3), 2.0) == 3
     @test flipsign(Sym(3), 0.0) == 3
     @test flipsign(Sym(3), -0.0) == -3


### PR DESCRIPTION
As discussed in issue #31 this lambdifies `sympy.sinc(x)` to use `sin(x)/x` and not `Base.sinc(x)` which uses `sin(pi*x)/(pi*x)`.