### PR TITLE
remove special  `view` method, add `symtype` function

### DIFF
--- a/src/SymPy/additional_methods_sympy.jl
+++ b/src/SymPy/additional_methods_sympy.jl
@@ -1,3 +1,13 @@
+"""
+    symtype(x=Sym(1))
+
+Return `Sym{T}` for `T` being the uderlying Python type of `x`.
+"""
+symtype(x::SymbolicObject{T}=Sym(1)) where {T} = Sym{T}
+export symtype
+
+
+
 # Math and other functions that don't fit metaprogramming pattern
 Base.log(x::Sym) = sympy.log(x) # generated method confuses two argument form
 Base.log(n::Number, x::Sym) = sympy.log(x, n) # Need to switch order here

--- a/src/SymPy/gen_methods_sympy.jl
+++ b/src/SymPy/gen_methods_sympy.jl
@@ -40,6 +40,8 @@ for (smeth, jmod, jmeth) ∈ SymPyCore.matrix_meths
     @eval begin
         ($(jmod).$(jmeth))(M::Matrix{T}, args...; kwargs...) where {T <: Sym} =
             ↑(↓(M).$(smeth)(↓(args)...; ↓ₖ(kwargs)...))
+        ($(jmod).$(jmeth))(M::SubArray{T,2}, args...; kwargs...) where {T <: Sym} =
+            ↑(↓(M).$(smeth)(↓(args)...; ↓ₖ(kwargs)...))
     end
 end
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -8,9 +8,12 @@ Base.promote_op(::O, ::Type{Sym{T}}, ::Type{S}) where {O,T, S <: Number} = Sym{T
 Base.promote_op(::O, ::Type{Sym{T}}, ::Type{Sym{T}}) where {O,T} = Sym{T} # This helps out linear alg
 
 Base.eachrow(M::Matrix{T}) where {T <: SymbolicObject} = (M[i,:] for i ∈ 1:size(M,1))
-function Base.view(A::AbstractArray{T,N}, I::Vararg{Any,M}) where {T <: SymbolicObject, N,M}
-    A[I...] # can't take view!!
-end
+
+# XXX for *some* reason this was a good idea. Doesn't seem to be necessary
+# now, but if that reason resurfaces, will have to see
+#function Base.view(A::AbstractArray{T,N}, I::Vararg{Any,M}) where {T <: SymbolicObject, N,M}
+#    A[I...] # can't take view!!
+#end
 
 call_matrix_meth(M::Matrix{T}, meth::Symbol, args...; kwargs...) where {T <: Sym} =
     ↑(getproperty(↓(M), meth)(↓(args)...; ↓ₖ(kwargs)...))

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,7 +39,6 @@ Sym(x::Tuple) = Tuple(Sym(xᵢ) for xᵢ ∈ x)
 Sym(x::Vector) = Sym[Sym(xᵢ) for xᵢ ∈ x]
 _pytype(::Sym{T}) where {T} = T
 
-
 Base.collect(s::Sym) = Sym.(collect(↓(s)))
 
 ## --------------------------------------------------

--- a/test/test-matrix.jl
+++ b/test/test-matrix.jl
@@ -200,4 +200,11 @@ using LinearAlgebra
     ls = eigvals(a)
     vs = eigvecs(a)
     @test simplify.(vs * Diagonal(ls) * inv(vs) -a) == 0*a
+
+    # issue #41 with views
+    A = zeros(symtype(), 2, 2)
+    A[1,1] = 1
+    @test A == [1 0; 0 0]
+    A[2,:] .= 2
+    @test A == [1 0; 2 2]
 end


### PR DESCRIPTION
Closes #41 

* FOr some reason, in development, a special method for `view` was defined. This no longer seems necessary, though if the issue resurfaces this PR will need to be rethought.