### PR TITLE
fix isless with oo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.1.14"
+version = "0.1.15"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -76,7 +76,7 @@ function Base.isless(x::S, y::S) where {T,S<:SymbolicObject{T}}
         sign(x) == -1 && return true
         sign(x) == 1  && return false
     end
-    if ifinf(y)
+    if isinf(y)
         sign(y) == -1 && return false
         sign(x) == 1  && return true
     end

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -72,6 +72,14 @@ Base.isless(::Missing, y::S)  where {T,S<:SymbolicObject{T}} = false
 function Base.isless(x::S, y::S) where {T,S<:SymbolicObject{T}}
 
     (isnan(x) || isnan(y)) && return !isnan(x)
+    if isinf(x)
+        sign(x) == -1 && return true
+        sign(x) == 1  && return false
+    end
+    if ifinf(y)
+        sign(y) == -1 && return false
+        sign(x) == 1  && return true
+    end
 
     u,v = convert(Bool3, x), convert(Bool3, y)
     u != nothing && v != nothing && return isless(u,v)


### PR DESCRIPTION
For some reason `compare` fails with `-oo < 1`. Might need to modify how `isless` is done.