### PR TITLE
fix bug in N(oo); add rsolve example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.1.16"
+version = "0.1.17"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -773,6 +773,19 @@ Here  is  one other way  to  express  the same
 Eq.( (2x+3y,3x-4y), (6,12)) |>  solve == d
 ```
 
+### Solving a linear recurrence
+
+The `rsolve` function solves univariate recurrence with rational coefficients. It's use is like `solve`, though we need to qualify it, as the function does not have a `Julia`n counterpart:
+
+```@repl introduction
+@syms y() n
+eqn = y(n) ~ y(n-1) + y(n-2)
+sympy.rsolve(eqn ,y(n))
+```
+
+A possibly familiar solution to the Fibonacci pattern is produced.
+
+
 ## Matrices
 
 A matrix of symbolic values could be represented in `Julia` as either a symbolic matrix or a matrix of symbolic elements. In `SymPy` the default is to use the latter:

--- a/src/SymPy/show_sympy.jl
+++ b/src/SymPy/show_sympy.jl
@@ -18,12 +18,14 @@ function Base.show(io::IO, ::MIME"text/plain", x::SymbolicObject)
     print(io, out)
 end
 
-# function Base.show(io::IO,  ::MIME"text/plain", x::Array{T, N}) where {N, T<:SymbolicObject)
-#     o = x.o
-#     out = string(_sympy_.printing.str.sstr(o)) # or .pretty
-#     out = replace(out, r"\*\*" => "^")
-#     print(io, out)
-# end
+#=
+function Base.show(io::IO,  ::MIME"text/plain", x::Array{T, N}) where {N, T<:SymbolicObject)
+    o = x.o
+    out = string(_sympy_.printing.str.sstr(o)) # or .pretty
+    out = replace(out, r"\*\*" => "^")
+    print(io, out)
+end
+=#
 
 ## --------------------------------------------------
 ## LaTeX printing
@@ -33,11 +35,11 @@ function Base.show(io::IO,  ::MIME"text/latex", x::SymbolicObject)
     print(io, string(out))
 end
 
-function  show(io::IO, ::MIME"text/latex", x::AbstractArray{Sym})
-    print(io, as_markdown(toeqnarray(x)))
+function  Base.show(io::IO, M::MIME"text/latex", x::AbstractArray{<:Sym})
+    show(io, M, sympy.ImmutableMatrix(x))
 end
 
-function show(io::IO, ::MIME"text/latex", d::Dict{T,S}) where {T<:SymbolicObject, S<:Any}
+function Base.show(io::IO, ::MIME"text/latex", d::Dict{T,S}) where {T<:SymbolicObject, S<:Any}
     Latex(x::Sym) = latex(x)
     Latex(x) = sprint(io -> show(IOContext(io, :compact => true), x))
 

--- a/src/numbers.jl
+++ b/src/numbers.jl
@@ -37,6 +37,15 @@ function N(x)
         cname == u && return v
     end
 
+    if x.is_infinite == true
+        if x.is_extended_real == true
+            x > 0 && return Inf
+            return -Inf
+        else
+            return  Complex(Inf, Inf)
+        end
+    end
+
     if _istree(x)
         z = y.evalf()
         if _convert(Bool, Sym(z.is_real))


### PR DESCRIPTION
* fixes bug with `float(oo)`
* Adds small example of using `rsolve` for recursive linear equation (close https://github.com/JuliaPy/SymPy.jl/issues/544 of SymPy)
* show arrays in latex (close https://github.com/JuliaPy/SymPy.jl/issues/543)