### PR TITLE
lambdify equation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.1.17"
+version = "0.1.18"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -362,6 +362,15 @@ function  lambdify(ex::Sym, vars=free_symbols(ex);
               use_julia_code=false,
               invoke_latest=true)
 
+    # what to do with equations?
+    if (ex.is_Equality == true)
+        return [
+            lambdify(ex.lhs, vars; fns, values, use_julia_code, invoke_latest),
+            lambdify(ex.rhs, vars; fns, values, use_julia_code, invoke_latest)
+        ]
+    end
+
+
     if isempty(vars)
         # can't call N(ex) here...
         v = ex.evalf()

--- a/test/test-legacy.jl
+++ b/test/test-legacy.jl
@@ -710,7 +710,8 @@ end
     F = SymFunction("F")
     diffeq = diff(F(t),t) - 3*F(t)
     res = dsolve(diffeq, F(t), ics=Dict(F(0) => 2))  # 2exp(3t)
-    @test lambdify(res)(1) ≈ 2*exp(3*1)
+    @test_broken lambdify(res)(1) ≈ 2*exp(3*1)
+    @test lambdify(res.rhs)(1) ≈ 2*exp(3*1)
 
     # issue 304 wrong values for sind, ...
     a = Sym(45)

--- a/test/test-math.jl
+++ b/test/test-math.jl
@@ -357,7 +357,9 @@ end
     @syms t, F()
     diffeq = diff(F(t),t) - 3*F(t)
     res = dsolve(diffeq, F(t), ics=Dict(F(0) => 2))  # 2exp(3t)
-    @test lambdify(res)(1) ≈ 2*exp(3*1)
+    @test_broken lambdify(res)(1) ≈ 2*exp(3*1)
+    @test lambdify(res.rhs)(1) ≈ 2*exp(3*1)
+
 
     # issue 304 wrong values for sind, ...
     a = Sym(45)


### PR DESCRIPTION
This has `lambdify(u ~ v) -> [lambdify(u), lambdify(v)]`. Which would make plotting of equations just work. It does break a test where evaluating a solution from `dsolve`. That isn't intended behaviour, so could be considered a bug (?)