### PR TITLE
Fix typo in intro.md

### DIFF
--- a/docs/src/Tutorial/intro.md
+++ b/docs/src/Tutorial/intro.md
@@ -178,7 +178,7 @@ with it:
 
 ```@repl Julia
 expr + 1
-expr = x
+expr - x
 ```
 
 ----


### PR DESCRIPTION
Should be `expr - x` instead of `expr = x` to follow with the python example.