### PR TITLE
hasproperty: delete type piracy and `String` -> `Symbol` fix

### DIFF
--- a/src/equality.jl
+++ b/src/equality.jl
@@ -30,7 +30,7 @@ function Base.:(==)(x::SymbolicObject, y::SymbolicObject)
     a == b == true  && return true
     a == b == false && return true
 
-    if hasproperty(↓(x), "equals") && hasproperty(↓(y), "equals")
+    if hasproperty(↓(x), :equals) && hasproperty(↓(y), :equals)
         u = ↑(↓(x).equals(↓(y)))
         v = Bool3(u)
         v == true && return true
@@ -38,8 +38,6 @@ function Base.:(==)(x::SymbolicObject, y::SymbolicObject)
     end
     return (hash(x) == hash(y))
 end
-
-Base.hasproperty(::Nothing, ::Any) = false
 
 # Bool3: used with ==; true, false or nothing
 Bool3(::Sym{Nothing}) = nothing
@@ -81,9 +79,9 @@ function Base.isless(x::S, y::S) where {T,S<:SymbolicObject{T}}
         return Lt(x, y) == Sym(true) ? true : false
     end
 
-    if hasproperty(↓(x), "compare")
+    if hasproperty(↓(x), :compare)
         out = x.compare(y)
-    elseif hasproperty(↓(y), "compare")
+    elseif hasproperty(↓(y), :compare)
         out = - (y.compare(x))
     else
         @show :huh_shouldnt_get_here, x, y

--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -91,7 +91,7 @@ end
 ## --------------------------------------------------
 # Methods for SymbolicUtils extension
 function _iscall(x::SymbolicObject)
-    hasproperty(↓(x), "is_Atom") && return !x.is_Atom
+    hasproperty(↓(x), :is_Atom) && return !x.is_Atom
     return false
 end
 

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -46,7 +46,7 @@ Base.inv(x::Sym) = ↑(↓(x).__pow__(-1))
 # strict conversion Sym(true) only
 function Base.convert(::Type{Bool}, x::Sym{T}) where {T}
     y = ↓(x)
-    hasproperty(y, "is_Boolean") && return _convert(Bool, y)
-    hasproperty(y, "__bool__") && return _convert(Bool, y)
+    hasproperty(y, :is_Boolean) && return _convert(Bool, y)
+    hasproperty(y, :__bool__) && return _convert(Bool, y)
     return false
 end


### PR DESCRIPTION
The deleted method was a blatant type piracy.