### PR TITLE
rework lambdify

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.9"
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -23,6 +24,7 @@ SymPyCoreTermInterfaceExt = "TermInterface"
 Aqua = "0.8"
 CommonEq = "0.2.1"
 CommonSolve = "0.2"
+GeneralizedGenerated = "0.3.3"
 Latexify = "0.15, 0.16"
 LinearAlgebra = "<0.0.1, 1.6"
 Markdown = "<0.0.1, 1.6"
@@ -42,4 +44,4 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua",  "TermInterface", "SparseArrays", "SymPyPythonCall", "Test"]
+test = ["Aqua", "TermInterface", "SparseArrays", "SymPyPythonCall", "Test"]

--- a/src/SymPy/additional_methods_sympy.jl
+++ b/src/SymPy/additional_methods_sympy.jl
@@ -90,6 +90,12 @@ function SymPyCore._convert_expr(use_julia_code::Val{true}, ex; kwargs...)
     Meta.parse(string(_sympy_.julia_code(↓(ex))))
 end
 
+function SymPyCore.julia_code(ex; kwargs...)
+    str = string(_sympy_.julia_code(↓(ex)))
+    str = replace(str, ".*" => "*", ".^" => "^")
+    Meta.parse(str)
+end
+
 
 # deprecations
 import Base: collect


### PR DESCRIPTION
Possible addition to #83.

This uses a more performant manner to produce lambda functions. With the addition to `walk_expressions` in #83, the use case becomes something like:

```
i =  sympy.Integral(1/(x + log(x)), (x, 1, 2))
d = Dict("Integral" => :∫)
using QuadGK
∫(f, I) = quadgk(f, I...)

FF = λfy(i; fns=d)
FF() # (0.5715168780107482, 3.2370106595180914e-11)
```

Is this kind of what you were expecting?