### PR TITLE
remove promote_type method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.2.11"
+version = "0.2.10"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -1,11 +1,8 @@
 Base.promote_rule(::Type{S}, ::Type{T})  where {S<:Number, T<:Sym}= T
-#Base.promote_rule(::Type{T}, ::Type{S})  where {T<:Sym, S<:Number}= T
-#Base.promote_rule(::Type{S}, ::Type{T})  where {S<:Irrational, T<:Sym}= T
 Base.promote_rule(::Type{S}, ::Type{T})  where {S<:AbstractIrrational, T<:Sym}= T
-#Base.promote_rule(::Type{T}, ::Type{S})  where {T<:Sym, S<:Irrational}= T
-#Base.promote_rule(::Type{Sym}, ::Type{Bool}) = Sym
 Base.promote_rule(::Type{Bool}, ::Type{T}) where {T <: Sym} = T
 Base.promote_rule(::Type{Bool}, ::Type{T}) where {T <: Sym{Nothing}} = Sym
+
 Base.promote_rule(::Type{Nothing}, ::Type{T}) where {T <: Sym} = T
 Base.promote_rule(::Type{Nothing}, ::Type{T}) where {T <: Sym{Nothing}} = Nothing
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -41,7 +41,9 @@ _pytype(::Sym{T}) where {T} = T
 
 Base.convert(::Type{Nothing}, ::Sym{Nothing}) = nothing
 
-Base.promote_type(::Type{Sym}, ::Type{Sym{T}})  where {T} = Sym{T}
+Base.promote_rule(::Type{Sym}, ::Type{Sym{T}})  where {T} = Sym{T}
+Base.promote_rule(::Type{Sym{T}}, ::Type{Sym})  where {T} = Sym{T}
+
 Base.collect(s::Sym) = Sym.(collect(↓(s)))
 
 ## --------------------------------------------------


### PR DESCRIPTION
close issue #39 by defining two promotion rules for `Sym` objects.