### PR TITLE
use NaN, not nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymPyCore"
 uuid = "458b697b-88f0-4a86-b56b-78b75cfb3531"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -204,7 +204,8 @@ val_map = Dict(
                "Exp1"             => :ℯ,
                "Infinity"         => :Inf,
                "NegativeInfinity" => :(-Inf),
-               "ComplexInfinity"  => :Inf, # error?
+    "ComplexInfinity"  => :Inf, # error?
+    "NaN" => :NaN,
                "ImaginaryUnit"    => :im,
                "BooleanTrue"      => :true,
                "BooleanFalse"     => :false
@@ -219,7 +220,7 @@ val_map = Dict(
 function _piecewise(args...)
     as = copy([args...])
     val, cond = pop!(as)
-    ex = Expr(:call, :ifelse, cond, convert(Expr,val), :nothing)
+    ex = Expr(:call, :ifelse, cond, convert(Expr,val), :NaN)
     while length(as) > 0
         val, cond = pop!(as)
         ex = Expr(:call, :ifelse, cond, convert(Expr,val), convert(Expr, ex))

--- a/test/test-math.jl
+++ b/test/test-math.jl
@@ -462,6 +462,11 @@ end
     λ = lambdify(u)
     @test all((iszero(λ(-1)), isone(λ(0)), isone(λ(1))))
 
+    ## lambdify piecewise without error PR #96
+    @syms t
+    v = sympy.Piecewise((1, Le(t, 0)))
+    vv = lambdify(v)
+    @test isnan(vv(1))
 
     ## Issue catch all for N; floats only
     @syms x


### PR DESCRIPTION
This change uses `NaN` and not `nothing` when there is no matching case for `Pieciewise` when converting by `lambdify`. This is more sensible for plotting.

Prompted by https://discourse.julialang.org/t/how-to-plot-a-sympy-jl-piecewise-function/130310/12